### PR TITLE
refactor(ComponentNodeSection): replace window.location with useNavigate

### DIFF
--- a/src/components/home/ComponentNodeSection.tsx
+++ b/src/components/home/ComponentNodeSection.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { useLanguage } from "../../LanguageContext";
 
 interface ComponentNodeSectionProps {
@@ -22,11 +23,12 @@ interface ComponentNodeSectionProps {
 
 export default function ComponentNodeSection({ data, url }: ComponentNodeSectionProps): React.ReactElement {
   const { currentLanguage } = useLanguage();
+  const navigate = useNavigate();
   const content = data[currentLanguage];
   
   const handleClick = () => {
     if (url) {
-      window.location.href = url;
+      navigate(url);
     }
   };
   


### PR DESCRIPTION
Use react-router's useNavigate hook for programmatic navigation instead of directly modifying window.location for better SPA behavior and consistency with routing library